### PR TITLE
Make it compatible with Node 4.2.1

### DIFF
--- a/ocreio.cc
+++ b/ocreio.cc
@@ -82,7 +82,10 @@ void OcrEio::Ocr(const FunctionCallbackInfo<Value>& args)
     return;
   }
   
-  if (!args[0]->ToObject()->GetConstructorName()->Equals(String::NewFromUtf8(isolate, "Buffer", String::kInternalizedString)))
+  // Add "Uint8Array" check to make it compatible with Node 4.2.1
+  //if (!args[0]->ToObject()->GetConstructorName()->Equals(String::NewFromUtf8(isolate, "Buffer", String::kInternalizedString)))
+  if ((!args[0]->ToObject()->GetConstructorName()->Equals(String::NewFromUtf8(isolate, "Buffer", String::kInternalizedString))) &&
+  (!args[0]->ToObject()->GetConstructorName()->Equals(String::NewFromUtf8(isolate, "Uint8Array", String::kInternalizedString))))
   {
     isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "Argument 1 must be an object of type Buffer", String::kInternalizedString)));
     scope.Escape(result);
@@ -236,7 +239,8 @@ void OcrEio::EIO_AfterOcr(uv_work_t *req, int status)
   Local<Value> argv[2];
   
   Isolate* isolate = Isolate::GetCurrent(); // fixme, see: https://strongloop.com/strongblog/node-js-v0-12-c-apis-breaking/
-
+  // Add below line to fix error "Cannot create a handle without a HandleScope"
+  HandleScope scope(isolate);
   argv[0] = Number::New(isolate, baton->error + status);
   argv[1] = String::NewFromUtf8(isolate, baton->textresult, String::kInternalizedString, strlen(baton->textresult));
 


### PR DESCRIPTION
To resolve Issue https://github.com/mdelete/node-tesseract-native/issues/9
In Node4.2.1, when passing Uint8Array buffer to ocr method, it throw exception "TypeError: Argument 1 must be an object of type Buffer".
So I added argument check for Unit8Array. 
After that change, it will throw exception "FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope" in OcrEio::EIO_AfterOcr() method, so I add "HandleScope scope(isolate);" to resolve that.