### PR TITLE
support node 4+ & tesseract psm

### DIFF
--- a/ocreio.h
+++ b/ocreio.h
@@ -45,6 +45,7 @@ class OcrEio : public node::ObjectWrap {
     OcrEio *oe;
     int error;
     char* language;
+    int psm;
     char* tessdata;
     char* textresult;
     int* rect;


### PR DESCRIPTION
### for node 4+:
https://github.com/mdelete/node-tesseract-native/pull/11#issue-127009012

### mainly support this option:
-psm N
Set Tesseract to only run a subset of layout analysis and assume a certain form of image. The options for N are:

0 = Orientation and script detection (OSD) only.
1 = Automatic page segmentation with OSD.
2 = Automatic page segmentation, but no OSD, or OCR.
3 = Fully automatic page segmentation, but no OSD. (Default)
4 = Assume a single column of text of variable sizes.
5 = Assume a single uniform block of vertically aligned text.
6 = Assume a single uniform block of text.
7 = Treat the image as a single text line.
8 = Treat the image as a single word.
9 = Treat the image as a single word in a circle.
10 = Treat the image as a single character.

https://tesseract-ocr.googlecode.com/git/doc/tesseract.1.html
